### PR TITLE
138 Fix setstate warning, turn on new eslint rule.

### DIFF
--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -456,7 +456,7 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-aws-sdk@^2.177.0:
+aws-sdk@2.177.0:
   version "2.177.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.177.0.tgz#d5fbf1f82bab250e55153699b030b44f687f600b"
   dependencies:
@@ -998,7 +998,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-preset-env@^1.6.1:
+babel-preset-env@1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.6.1.tgz#a18b564cc9b9afdf4aae57ae3c1b0d99188e6f48"
   dependencies:
@@ -1033,7 +1033,7 @@ babel-preset-env@^1.6.1:
     invariant "^2.2.2"
     semver "^5.3.0"
 
-babel-preset-stage-0@^6.24.1:
+babel-preset-stage-0@6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz#5642d15042f91384d7e5af8bc88b1db95b039e6a"
   dependencies:
@@ -1178,19 +1178,19 @@ bluebird@3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.2.2.tgz#164347d3fcab21eca9db849b4b856bec96041051"
 
+bluebird@3.5.1, bluebird@^3.3.4, bluebird@^3.4.6, bluebird@^3.5.0, bluebird@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
 bluebird@^2.9.24:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
-
-bluebird@^3.3.4, bluebird@^3.4.6, bluebird@^3.5.0, bluebird@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
-body-parser@1.18.2, body-parser@^1.18.2:
+body-parser@1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"
   dependencies:
@@ -1652,7 +1652,7 @@ connect-history-api-fallback@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
 
-connect-static-file@^2.0.0:
+connect-static-file@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/connect-static-file/-/connect-static-file-2.0.0.tgz#c18ea2fbefb3e4442f6d9bfcad23c6de16a79433"
   dependencies:
@@ -1694,7 +1694,7 @@ convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
-cookie-parser@^1.4.3:
+cookie-parser@1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.3.tgz#0fe31fa19d000b95f4aadf1f53fdc2b8a203baa5"
   dependencies:
@@ -1732,7 +1732,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cors@^2.8.4:
+cors@2.8.4:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.4.tgz#2bd381f2eb201020105cd50ea59da63090694686"
   dependencies:
@@ -1850,7 +1850,7 @@ dasherize@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dasherize/-/dasherize-2.0.0.tgz#6d809c9cd0cf7bb8952d80fc84fa13d47ddb1308"
 
-dataloader@^1.4.0:
+dataloader@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
 
@@ -2276,7 +2276,7 @@ eslint-config-airbnb-base@^12.1.0:
   dependencies:
     eslint-restricted-globals "^0.1.1"
 
-eslint-config-airbnb@^16.1.0:
+eslint-config-airbnb@16.1.0:
   version "16.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-16.1.0.tgz#2546bfb02cc9fe92284bf1723ccf2e87bc45ca46"
   dependencies:
@@ -3756,7 +3756,7 @@ jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
 
-joi@^13.1.2:
+joi@13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/joi/-/joi-13.1.2.tgz#b2db260323cc7f919fafa51e09e2275bd089a97e"
   dependencies:
@@ -3876,7 +3876,7 @@ jwa@^1.1.4:
     ecdsa-sig-formatter "1.0.9"
     safe-buffer "^5.0.1"
 
-jwks-rsa@^1.2.1:
+jwks-rsa@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/jwks-rsa/-/jwks-rsa-1.2.1.tgz#9949100f5643821107787de2947d46f875f6ab5a"
   dependencies:
@@ -3911,27 +3911,7 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
-knex@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-0.9.0.tgz#305a1a103cdbf50bf51fb80ff4e3b26d8f9bb850"
-  dependencies:
-    bluebird "^2.9.24"
-    chalk "^1.0.0"
-    commander "^2.2.0"
-    debug "^2.1.3"
-    inherits "~2.0.1"
-    interpret "^0.6.5"
-    liftoff "~2.0.0"
-    lodash "^3.7.0"
-    minimist "~1.1.0"
-    mkdirp "^0.5.0"
-    pg-connection-string "^0.1.3"
-    pool2 "^1.1.0"
-    readable-stream "^1.1.12"
-    tildify "~1.0.0"
-    v8flags "^2.0.2"
-
-knex@^0.14.0:
+knex@0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/knex/-/knex-0.14.0.tgz#dd4569821141429c4e6b0bb5d8068874cdb50cc3"
   dependencies:
@@ -3953,6 +3933,26 @@ knex@^0.14.0:
     tildify "1.2.0"
     uuid "^3.0.0"
     v8flags "^3.0.0"
+
+knex@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-0.9.0.tgz#305a1a103cdbf50bf51fb80ff4e3b26d8f9bb850"
+  dependencies:
+    bluebird "^2.9.24"
+    chalk "^1.0.0"
+    commander "^2.2.0"
+    debug "^2.1.3"
+    inherits "~2.0.1"
+    interpret "^0.6.5"
+    liftoff "~2.0.0"
+    lodash "^3.7.0"
+    minimist "~1.1.0"
+    mkdirp "^0.5.0"
+    pg-connection-string "^0.1.3"
+    pool2 "^1.1.0"
+    readable-stream "^1.1.12"
+    tildify "~1.0.0"
+    v8flags "^2.0.2"
 
 latest-version@^3.0.0:
   version "3.1.0"
@@ -4487,7 +4487,7 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
-morgan@^1.9.0:
+morgan@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.0.tgz#d01fa6c65859b76fcf31b3cb53a3821a311d8051"
   dependencies:
@@ -4516,7 +4516,7 @@ ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
-multer@^1.3.0:
+multer@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/multer/-/multer-1.3.0.tgz#092b2670f6846fa4914965efc8cf94c20fec6cd2"
   dependencies:
@@ -4615,7 +4615,7 @@ node-pre-gyp@^0.6.39:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-nodemon@^1.12.1:
+nodemon@1.12.1:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.12.1.tgz#996a56dc49d9f16bbf1b78a4de08f13634b3878d"
   dependencies:
@@ -4715,7 +4715,7 @@ object.pick@^1.2.0:
   dependencies:
     isobject "^3.0.1"
 
-objection@^0.9.0:
+objection@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/objection/-/objection-0.9.0.tgz#45f1b85205274f7ebd506e16be1b2f577b780250"
   dependencies:
@@ -5612,7 +5612,7 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-sanitize-html@^1.18.2:
+sanitize-html@1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.18.2.tgz#61877ba5a910327e42880a28803c2fbafa8e4642"
   dependencies:
@@ -5773,7 +5773,7 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shortid@^2.2.8:
+shortid@2.2.8:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.8.tgz#033b117d6a2e975804f6f0969dbe7d3d0b355131"
 
@@ -5908,7 +5908,7 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-sql-fixtures@^1.0.0:
+sql-fixtures@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sql-fixtures/-/sql-fixtures-1.0.0.tgz#6db4d116837dfa8e2e892c1548db10a2ddec73e6"
   dependencies:
@@ -6506,7 +6506,7 @@ webpack-dev-middleware@^1.11.0:
     range-parser "^1.0.3"
     time-stamp "^2.0.0"
 
-webpack-dev-server@^2.9.4:
+webpack-dev-server@2.9.4:
   version "2.9.4"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.9.4.tgz#7883e61759c6a4b33e9b19ec4037bd4ab61428d1"
   dependencies:
@@ -6538,7 +6538,7 @@ webpack-dev-server@^2.9.4:
     webpack-dev-middleware "^1.11.0"
     yargs "^6.6.0"
 
-webpack-node-externals@^1.7.2:
+webpack-node-externals@1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
 

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -4,6 +4,7 @@
     "quotes": [2, "single"],
     "semi": 1,     // come on! Gotta have ; set it to warn(1) otherwise react stops rendering
     "object-curly-spacing": [1, "always"],
-    "comma-dangle": [1, "never"]
+    "comma-dangle": [1, "never"],
+    "react/no-access-state-in-setstate": [2]
   }
 }

--- a/client/src/components/Games/View/Join/index.js
+++ b/client/src/components/Games/View/Join/index.js
@@ -122,17 +122,22 @@ const JoinGame = class JoinGame extends Component {
   _setCharacter = (character) => {
     const value = _.get(character, 'value', null);
 
-    const { store } = this.state;
-    _.set(store, 'characterId', value);
-    this.setState({ ...this.state, store });
+    this.setState(prevState => {
+      const { store } = prevState;
+      _.set(store, 'characterId', value);
+
+      return { store };
+    });
   };
 
   _formInput = (stateKey) => {
     return (e) => {
-      const { store } = this.state;
+      this.setState(prevState => {
+        const { store } = prevState;
+        _.set(store, stateKey, e.target.value);
 
-      _.set(store, stateKey, e.target.value);
-      this.setState({ ...this.state, store });
+        return { store };
+      });
     };
   };
 

--- a/client/src/components/Games/View/components/GameMessages/CreateMessage/index.js
+++ b/client/src/components/Games/View/components/GameMessages/CreateMessage/index.js
@@ -71,8 +71,10 @@ class CreateMessage extends Component {
   };
 
   _handlePostType = (postType) => {
-    const form = _.merge({}, this.state.form, postType);
-    this.setState({ form });
+    this.setState(prevState => {
+      const form = _.merge({}, prevState.form, postType);
+      return { form };
+    });
   };
 
   _submit = () => {

--- a/client/src/components/Games/components/GameDetailsForm/index.js
+++ b/client/src/components/Games/components/GameDetailsForm/index.js
@@ -214,18 +214,22 @@ class GameDetailsForm extends Component {
 
   _formInput = (stateKey) => {
     return (e) => {
-      const { store } = this.state;
+      this.setState(prevState => {
+        const { store } = prevState;
+        _.set(store, stateKey, e.target.value);
 
-      _.set(store, stateKey, e.target.value);
-      this.setState({ ...this.state, store });
+        return { store };
+      });
     };
   };
 
   _handleOverview = (message) => {
-    const { store } = this.state;
+    this.setState(prevState => {
+      const { store } = prevState;
+      _.set(store, 'overview', message.content);
 
-    _.set(store, 'overview', message.content);
-    this.setState({ ...this.state, store });
+      return { store };
+    });
   };
 
   _formValue = (stateKey) => {

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -65,7 +65,7 @@ class NavBarMobile extends Component {
   }
 
   _toggleMenu = () => {
-    this.setState({ visible: !this.state.visible });
+    this.setState(prevState => ({ visible: !prevState.visible }));
   };
 
 }

--- a/client/src/components/Login/AlmostFinished/index.js
+++ b/client/src/components/Login/AlmostFinished/index.js
@@ -123,11 +123,12 @@ class AlmostFinished extends Component {
     let file = e.target.files[0];
 
     reader.onloadend = () => {
-      const { store } = this.state;
+      this.setState(prevState => {
+        const { store } = prevState;
+        store.profileImageUrl = reader.result;
 
-      store.profileImageUrl = reader.result;
-
-      this.setState({ ...this.state, store });
+        return { store };
+      });
       this.setState({ file });
     };
 
@@ -167,19 +168,24 @@ class AlmostFinished extends Component {
 
   _formInput = (stateKey) => {
     return (e) => {
-      const { store } = this.state;
+      this.setState(prevState => {
+        const { store } = prevState;
+        _.set(store, stateKey, e.target.value);
 
-      _.set(store, stateKey, e.target.value);
-      this.setState({ ...this.state, store });
+        return { store };
+      });
     };
   };
 
   _setTimezone = (timezone) => {
     const value = _.get(timezone, 'value', null);
 
-    const { store } = this.state;
-    _.set(store, 'timezone', value);
-    this.setState({ ...this.state, store });
+    this.setState(prevState => {
+      const { store } = prevState;
+      _.set(store, 'timezone', value);
+
+      return { store };
+    });
   };
 
   _formValue = (stateKey) => {
@@ -246,4 +252,3 @@ export default compose(
   }),
   connect(null, mapDispatchToProps, null, { pure: false }),
 )(AlmostFinished);
-

--- a/client/src/components/Settings/index.js
+++ b/client/src/components/Settings/index.js
@@ -16,15 +16,6 @@ import { getProfile } from '../../services/webAuth';
 import { getMyDetails } from '../../actions/me';
 
 class Settings extends Component {
-  constructor() {
-    super();
-
-    getProfile()
-      .then(profile => {
-        this.setState({ profile });
-      });
-  }
-
   state = {
     activeItem: 'profile',
     displaySuccess: false,
@@ -38,6 +29,13 @@ class Settings extends Component {
     // the form validity state
     errors: {}
   };
+
+  componentDidMount() {
+    getProfile()
+      .then(profile => {
+        this.setState({ profile });
+      });
+  }
 
   static getDerivedStateFromProps(props) {
     return {

--- a/client/src/components/Settings/index.js
+++ b/client/src/components/Settings/index.js
@@ -5,7 +5,7 @@ import { graphql } from 'react-apollo';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { compose } from 'recompose';
-import { Button, Container, Form, Grid, 
+import { Button, Container, Form, Grid,
   Header, Icon, Image, Label, Menu, Message } from 'semantic-ui-react';
 
 import SuccessToast from '../shared/components/SuccessToast';
@@ -16,7 +16,16 @@ import { getProfile } from '../../services/webAuth';
 import { getMyDetails } from '../../actions/me';
 
 class Settings extends Component {
-  state = { 
+  constructor() {
+    super();
+
+    getProfile()
+      .then(profile => {
+        this.setState({ profile });
+      });
+  }
+
+  state = {
     activeItem: 'profile',
     displaySuccess: false,
     // the form control state
@@ -30,22 +39,15 @@ class Settings extends Component {
     errors: {}
   };
 
-  componentWillMount() {
-    return getProfile()
-      .then(profile => {
-        this.setState({ profile });
-      });
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this.setState({
+  static getDerivedStateFromProps(props) {
+    return {
       store: {
-        username: _.get(nextProps.data, 'me.username') || '',
-        name: _.get(nextProps.data, 'me.name') || '',
-        timezone: _.get(nextProps.data, 'me.timezone') || '',
-        profileImageUrl: _.get(nextProps.data, 'me.profileImage.url') || ''
+        username: _.get(props.data, 'me.username') || '',
+        name: _.get(props.data, 'me.name') || '',
+        timezone: _.get(props.data, 'me.timezone') || '',
+        profileImageUrl: _.get(props.data, 'me.profileImage.url') || ''
       }
-    });
+    };
   }
 
   render() {
@@ -116,7 +118,7 @@ class Settings extends Component {
                       readOnly
                       width={6}
                     />
-                    {emailVerified ? 
+                    {emailVerified ?
                       (<Label pointing='left'>Verified <Icon color='green' size='big' name='check circle' /></Label>) :
                       <Button>Resend Verification Email</Button>
                     }
@@ -163,11 +165,12 @@ class Settings extends Component {
     let file = e.target.files[0];
 
     reader.onloadend = () => {
-      const { store } = this.state;
+      this.setState(prevState => {
+        const { store } = prevState;
+        store.profileImageUrl = reader.result;
 
-      store.profileImageUrl = reader.result;
-
-      this.setState({ ...this.state, store });
+        return { store };
+      });
       this.setState({ file });
     };
 
@@ -207,19 +210,24 @@ class Settings extends Component {
 
   _formInput = (stateKey) => {
     return (e) => {
-      const { store } = this.state;
+      this.setState(prevState => {
+        const { store } = prevState;
+        _.set(store, stateKey, e.target.value);
 
-      _.set(store, stateKey, e.target.value);
-      this.setState({ ...this.state, store });
+        return { store };
+      });
     };
   };
 
   _setTimezone = (timezone) => {
     const value = _.get(timezone, 'value', null);
 
-    const { store } = this.state;
-    _.set(store, 'timezone', value);
-    this.setState({ ...this.state, store });
+    this.setState(prevState => {
+      const { store } = prevState;
+      _.set(store, 'timezone', value);
+
+      return { store };
+    });
   };
 
   _formValue = (stateKey) => {


### PR DESCRIPTION
Closes #138 

- [X] Make fixes to `setState` calls. Notice most of the use cases required the same fix. I don't think there is a reason to use `...this.state`
- [X] fixed bug on Settings page where the data wasn't loading when transitioning from another page. It worked on fresh pageload. Fixed by updating to 16.3 lifecycle events.
