### PR TITLE
closes #140 - warning in controlled element on Settings page - email field

### DIFF
--- a/client/src/components/Settings/index.js
+++ b/client/src/components/Settings/index.js
@@ -109,18 +109,20 @@ class Settings extends Component {
                     </Message>
                   </Form.Field>
 
-                  <Form.Group inline>
-                    <Form.Input
-                      label='Email'
-                      value={email}
-                      readOnly
-                      width={6}
-                    />
-                    {emailVerified ?
-                      (<Label pointing='left'>Verified <Icon color='green' size='big' name='check circle' /></Label>) :
-                      <Button>Resend Verification Email</Button>
-                    }
-                  </Form.Group>
+                  { email && (
+                    <Form.Group inline>
+                      <Form.Input
+                        label='Email'
+                        value={email}
+                        readOnly
+                        width={6}
+                      />
+                      {emailVerified ?
+                        (<Label pointing='left'>Verified <Icon color='green' size='big' name='check circle' /></Label>) :
+                        <Button>Resend Verification Email</Button>
+                      }
+                    </Form.Group>
+                  )}
 
                   <Form.Field required>
                     <label>Name</label>


### PR DESCRIPTION
This was a warning and is triggered since the email input is initially rendered with a null email value (un-controlled) and again once an email is fetched to the db (controlled).

I updated the code so that the email input is only rendered when there is an email