### PR TITLE
Misc be sure to also copy over .env file.

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -15,8 +15,7 @@ COPY /scripts /usr/src/app/scripts
 COPY /src /usr/src/app/src
 
 # copy specific build target env files
-COPY .env.production .
-COPY .env.playquest .
+COPY .env.* .
 
 RUN mkdir /usr/src/app/build
 


### PR DESCRIPTION
Simple change, one question @nazar  how come in the similar DS change the command was: 
`COPY .env.* /usr/src/app/` notice the different destination as opposed to `.` here?


*edit*:  is it because of this command a few lines up? `WORKDIR /usr/src/app`