### PR TITLE
closes #155 - set a max height on the game description

### DIFF
--- a/client/src/components/Games/components/GameCard/gameCard.styl
+++ b/client/src/components/Games/components/GameCard/gameCard.styl
@@ -1,0 +1,12 @@
+.game-card-component
+  .truncated
+    max-height 80px
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-box-orient: horizontal;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+
+    & > *
+      line-height 20px

--- a/client/src/components/Games/components/GameCard/index.js
+++ b/client/src/components/Games/components/GameCard/index.js
@@ -6,6 +6,7 @@ import { Card, Icon, Image } from 'semantic-ui-react';
 
 import { postingFrequency, skillLevel } from '../../utils/gameSettings';
 import dragons from './dragons.jpg';
+import './gameCard.styl';
 
 export default class GameCard extends Component {
 
@@ -19,7 +20,7 @@ export default class GameCard extends Component {
     const imageSrc = _.get(game, 'gameImage.url') || dragons;
 
     return (
-      <Card>
+      <Card className="game-card-component">
         <Image src={imageSrc}
                label={{ as: 'a', color: 'red', content: shortName, ribbon: true }}
         />
@@ -31,7 +32,7 @@ export default class GameCard extends Component {
             {game.scenario}
           </Card.Meta>
           <Card.Description>
-            <div dangerouslySetInnerHTML={{ __html: game.overview }} />
+            <div className="truncated" dangerouslySetInnerHTML={{ __html: game.overview }} />
           </Card.Description>
         </Card.Content>
         <Card.Content extra>


### PR DESCRIPTION
Hey @mikelax 

It's tricky getting ellipses to work on multiline text, more so if the text has nested components like we do in the `description` field, which is produced by tinyMCE and contains nested `p` elements for paragraphs.

I've limited the description to four lines for now.