### PR TITLE
WIP 178 hide quote button for non-player.

### DIFF
--- a/client/src/components/Games/View/ViewGameLoungeMessages.js
+++ b/client/src/components/Games/View/ViewGameLoungeMessages.js
@@ -1,7 +1,9 @@
+import PropTypes from 'prop-types';
 import React from 'react';
-import { Segment } from 'semantic-ui-react';
+import { Message, Segment } from 'semantic-ui-react';
 import { graphql } from 'react-apollo/index';
-import { compose, pure } from 'recompose';
+import { compose } from 'recompose';
+import { connect } from 'react-redux';
 
 import GameHeader from './GameHeader';
 import CreateLoungeMessage from './components/CreateLoungeMessage';
@@ -10,7 +12,7 @@ import GameLoungeMessages from './components/GameLoungeMessages';
 import { gameQuery } from '../queries';
 
 function GameLoungeMessagesView (props) {
-  const { match: { params: { id } }, data: { game } } = props;
+  const { match: { params: { id } }, data: { game }, authorisation: { isAuthenticated } } = props;
 
   return (
     <React.Fragment>
@@ -19,15 +21,36 @@ function GameLoungeMessagesView (props) {
       <GameLoungeMessages gameId={id}/>
 
       <Segment>
-        <CreateLoungeMessage gameId={id}/>
+        { isAuthenticated && <CreateLoungeMessage gameId={id}/> }
+        { !isAuthenticated && <LoginToPostMessage /> }
       </Segment>
     </React.Fragment>
   );
 }
 
+GameLoungeMessagesView.propTypes = {
+  authorisation: PropTypes.shape({
+    isAuthenticated: PropTypes.bool.isRequired
+  }).isRequired
+};
+
+function LoginToPostMessage() {
+  return (
+    <Message
+      info
+      header='Please Login to Post'
+      content='While the Game Lounge is viewable by everyone, you must be logged in to post a new Message.'
+    />
+  );
+}
+
+const mapStateToProps = state => ({
+  authorisation: state.authorisation
+});
+
 export default compose(
+  connect(mapStateToProps),
   graphql(gameQuery, {
     options: ( { match: { params: { id } } } ) => ({ variables: { id } })
   }),
-  pure,
 )(GameLoungeMessagesView);

--- a/client/src/components/Games/View/ViewGameMessages.js
+++ b/client/src/components/Games/View/ViewGameMessages.js
@@ -20,7 +20,7 @@ function ViewGameMessages(props) {
     <React.Fragment>
       <GameHeader game={game} />
 
-      <GameMessages gameId={_.toInteger(game.id)}/>
+      <GameMessages gameId={game.id}/>
 
       <Segment>
         <EditorBlock myGamePlayer={myGamePlayer} game={game}/>

--- a/client/src/components/Games/View/ViewGameMessages.js
+++ b/client/src/components/Games/View/ViewGameMessages.js
@@ -7,7 +7,7 @@ import { graphql } from 'react-apollo';
 
 import GameHeader from './GameHeader';
 import CreateMessage from './components/GameMessages/CreateMessage';
-import GamesMessages from './components/GameMessages';
+import GameMessages from './components/GameMessages';
 import { gameQuery, myGamePlayerQuery } from '../queries';
 
 import ApolloLoader from 'components/shared/ApolloLoader';
@@ -20,7 +20,7 @@ function ViewGameMessages(props) {
     <React.Fragment>
       <GameHeader game={game} />
 
-      <GamesMessages gameId={game.id}/>
+      <GameMessages gameId={_.toInteger(game.id)}/>
 
       <Segment>
         <EditorBlock myGamePlayer={myGamePlayer} game={game}/>

--- a/client/src/components/Games/View/components/GameMessages/index.js
+++ b/client/src/components/Games/View/components/GameMessages/index.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import moment from 'moment';
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { graphql } from 'react-apollo';
 import { compose } from 'recompose';
@@ -73,6 +74,10 @@ export default function GameMessages(props) {
     </UberPaginator>
   );
 }
+
+GameMessages.propTypes = {
+  gameId: PropTypes.number.isRequired
+};
 
 class MessagesRenderer extends Component {
 


### PR DESCRIPTION
This was a start to hide the Quote buttons for non-players. 

@nazar  I have a question on this. Currently we are only looking at if the user is logged in or not in the `_viewingControls` function where we set the `canPost` attribute. 

This also needs to check if the user is a player in the game. 
In `ViewGameMessages`, I was going to pass a new property of `myGamePlayer={myGamePlayer}` to `GameMessages`. I then realized though that this prop would then have to be passed down to: 

MessagesRenderer -> GameMessageContainer -> GameMessage

I am not sure if this is the "right" approach, plus I wasn't sure if that was the right approach given the props we may need to track for #177 