### PR TITLE
#178 - Various permission check tweaks and fixes

### DIFF
--- a/api/src/schemas/user.js
+++ b/api/src/schemas/user.js
@@ -13,7 +13,7 @@ export const userTypeDefs = `
   }
 
   type User {
-    id: Int!,
+    id: ID!,
     name: String,
     username: String,
     timezone: String,

--- a/client/src/components/Games/View/ViewGameLoungeMessages.js
+++ b/client/src/components/Games/View/ViewGameLoungeMessages.js
@@ -34,15 +34,13 @@ GameLoungeMessagesView.propTypes = {
   }).isRequired
 };
 
-function LoginToPostMessage() {
-  return (
-    <Message
-      info
-      header='Please Login to Post'
-      content='While the Game Lounge is viewable by everyone, you must be logged in to post a new Message.'
-    />
-  );
-}
+const LoginToPostMessage = () => (
+  <Message
+    info
+    header='Please Login to Post'
+    content='While the Game Lounge is viewable by everyone, you must be logged in to post a new Message.'
+  />
+);
 
 const mapStateToProps = state => ({
   authorisation: state.authorisation

--- a/client/src/components/Games/View/components/GameLoungeMessages/gameLoungeMessages.styl
+++ b/client/src/components/Games/View/components/GameLoungeMessages/gameLoungeMessages.styl
@@ -17,6 +17,10 @@
         margin-top .5rem !important
         margin-bottom .5rem  !important
 
+      .column-meta
+        margin-top .5rem !important
+        margin-bottom 0  !important
+
     .row.header-row
       .column
         margin-bottom 0 !important

--- a/client/src/components/Games/View/components/GameLoungeMessages/index.js
+++ b/client/src/components/Games/View/components/GameLoungeMessages/index.js
@@ -162,6 +162,8 @@ class GameLoungeMessageContainer extends Component {
           </Grid.Column>
         </Grid.Row>
 
+        <MetaRow loungeMessage={loungeMessage} />
+
         <Grid.Row>
           <Grid.Column className="column-message">
             <RichEditor message={loungeMessage.message} ref={this.editor} readOnly={!(editing)} />
@@ -275,6 +277,26 @@ class GameLoungeMessageContainer extends Component {
 
     return <span className="date" title={dateDisplayActual}>{dateDisplayRelative}</span>;
   };
+}
+
+function MetaRow(props) {
+  const { loungeMessage: { user, meta } }  = props;
+
+  return meta && (
+    <Grid.Row className="slim">
+      <Grid.Column className="column-meta">
+        <Joined />
+      </Grid.Column>
+    </Grid.Row>
+  );
+
+  function Joined() {
+    const joined = meta === 'join';
+
+    return joined && (
+      <Message color='teal' size="mini">{user.name} applied to join the game.</Message>
+    );
+  }
 }
 
 const mapDispatchToProps = dispatch => ({

--- a/client/src/components/Games/View/components/GameMessages/index.js
+++ b/client/src/components/Games/View/components/GameMessages/index.js
@@ -120,7 +120,10 @@ class MessagesRenderer extends Component {
     const { myGamePlayer } = myGamePlayerData;
     const currentUserId = _.get(meQueryData, 'me.id');
 
-    return _.some(myGamePlayer, mgp => Number(mgp.user.id) === Number(currentUserId));
+    return _.some(myGamePlayer, mgp =>
+      Number(mgp.user.id) === Number(currentUserId)
+        && _.includes(['accepted', 'game-master'], mgp.status)
+    );
   });
 
   _messageBelongsToCurrentUser = (gameMessage, meQueryData) => {

--- a/client/src/components/Profile/index.js
+++ b/client/src/components/Profile/index.js
@@ -86,7 +86,7 @@ function ProfileHeader(props) {
   const { dataGamesSummary, loadingSummary, loadingCharacters } = props;
 
   const charactersCount = _.get(props, 'dataCharacters.charactersCount');
-  const activeGamesCount = _.find(dataGamesSummary, (summary) => _.includes(['accepted', 'games-master'], summary.status));
+  const activeGamesCount = _.find(dataGamesSummary, ({ status }) => _.includes(['accepted', 'game-master'], status));
   const pendingGamesCount = _.find(dataGamesSummary, { status: 'pending' });
   const kickedGamesCount = _.find(dataGamesSummary, { status: 'kicked' });
 

--- a/client/src/components/Profile/index.js
+++ b/client/src/components/Profile/index.js
@@ -86,9 +86,14 @@ function ProfileHeader(props) {
   const { dataGamesSummary, loadingSummary, loadingCharacters } = props;
 
   const charactersCount = _.get(props, 'dataCharacters.charactersCount');
-  const activeGamesCount = _.find(dataGamesSummary, ({ status }) => _.includes(['accepted', 'game-master'], status));
   const pendingGamesCount = _.find(dataGamesSummary, { status: 'pending' });
   const kickedGamesCount = _.find(dataGamesSummary, { status: 'kicked' });
+  
+  const activeGamesCount = _.chain(dataGamesSummary)
+    .filter(({ status }) => _.includes(['accepted', 'game-master'], status))
+    .map('statusCount')
+    .sum()
+    .value();
 
   return (
     <div className="user-profile-header">

--- a/client/src/components/Profile/index.js
+++ b/client/src/components/Profile/index.js
@@ -86,6 +86,7 @@ function ProfileHeader(props) {
   const { dataGamesSummary, loadingSummary, loadingCharacters } = props;
 
   const charactersCount = _.get(props, 'dataCharacters.charactersCount');
+  const activeGamesCount = _.find(dataGamesSummary, (summary) => _.includes(['accepted', 'games-master'], summary.status));
   const pendingGamesCount = _.find(dataGamesSummary, { status: 'pending' });
   const kickedGamesCount = _.find(dataGamesSummary, { status: 'kicked' });
 
@@ -111,7 +112,7 @@ function ProfileHeader(props) {
           <Icon name='comments' loading={loadingSummary} />
           Current Games
           <Label>
-            {_.size(dataGamesSummary)}
+            {_.get(activeGamesCount, 'statusCount', 0)}
           </Label>
         </Menu.Item>
 

--- a/client/src/components/Profile/index.js
+++ b/client/src/components/Profile/index.js
@@ -88,7 +88,7 @@ function ProfileHeader(props) {
   const charactersCount = _.get(props, 'dataCharacters.charactersCount');
   const pendingGamesCount = _.find(dataGamesSummary, { status: 'pending' });
   const kickedGamesCount = _.find(dataGamesSummary, { status: 'kicked' });
-  
+
   const activeGamesCount = _.chain(dataGamesSummary)
     .filter(({ status }) => _.includes(['accepted', 'game-master'], status))
     .map('statusCount')
@@ -117,7 +117,7 @@ function ProfileHeader(props) {
           <Icon name='comments' loading={loadingSummary} />
           Current Games
           <Label>
-            {_.get(activeGamesCount, 'statusCount', 0)}
+            {activeGamesCount}
           </Label>
         </Menu.Item>
 


### PR DESCRIPTION
1. game message edit controls only available to accepted game players and GM
2. update mutation to check for valid game players before creating a game message
3. restore game lounge meta (i.e. joined game) section which was lost during a refactor